### PR TITLE
Corrected allowed message from 'has taken fork' to 'has taken a fork'

### DIFF
--- a/src/philo/event.py
+++ b/src/philo/event.py
@@ -24,7 +24,7 @@ class Event(enum.Enum):
     @staticmethod
     def from_string(representation: str) -> "Event":
         return {
-            "has taken fork": Event.FORK,
+            "has taken a fork": Event.FORK,
             "is thinking":    Event.THINK,
             "is eating":      Event.EAT,
             "is sleeping":    Event.SLEEP,
@@ -34,7 +34,7 @@ class Event(enum.Enum):
     @staticmethod
     def to_string(event: "Event") -> str:
         return {
-            Event.FORK:  "has taken fork",
+            Event.FORK:  "has taken a fork",
             Event.THINK: "is thinking",
             Event.EAT:   "is eating",
             Event.SLEEP: "is sleeping",

--- a/src/philo/log.py
+++ b/src/philo/log.py
@@ -21,7 +21,7 @@ class Log:
         match = re.match(
             r"^(?P<timestamp>\d+) "
             r"(?P<id>\d+) "
-            r"(?P<event>is thinking|is eating|is sleeping|died|has taken fork)$",
+            r"(?P<event>is thinking|is eating|is sleeping|died|has taken a fork)$",
             line
         )
         if match is None:


### PR DESCRIPTION
The message for a philosopher taking a fork has the article 'a' (see subject of Philosophers and Old_Philosophers).
This commit fixes it.